### PR TITLE
Reference parent project directly in example code

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const express = require('express');
-const assets = require('govuk-react-components').assets;
+const assets = require('../').assets;
 
 const app = express();
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -896,22 +896,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
-    "govuk-react-components": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/govuk-react-components/-/govuk-react-components-0.0.8.tgz",
-      "integrity": "sha512-zYj4cytR+8gwdqvBEp2YoMhaLN6W1+wkEWhtRejhms+9pWJtiFy1nZ+LZUucXu2Z5Un7sVBpahDh6CgT6rGB1Q==",
-      "requires": {
-        "express": "4.16.2",
-        "govuk_template_mustache": "0.23.0",
-        "prop-types": "15.6.0",
-        "react": "16.2.0"
-      }
-    },
-    "govuk_template_mustache": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/govuk_template_mustache/-/govuk_template_mustache-0.23.0.tgz",
-      "integrity": "sha1-OEr65LJXLPSLqKClYhLxw9jBXys="
-    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",

--- a/example/package.json
+++ b/example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-react-example",
   "version": "1.0.0",
-  "description": "",
+  "description": "An example implementation of the components",
   "main": "index.js",
   "scripts": {
     "start": "node index.js"
@@ -11,7 +11,6 @@
   "dependencies": {
     "express": "^4.16.2",
     "express-react-views": "^0.10.4",
-    "govuk-react-components": "0.0.8",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"
   }

--- a/example/views/index.jsx
+++ b/example/views/index.jsx
@@ -1,10 +1,10 @@
 const React = require('react');
 const Layout = require('./layout');
 
-const Input = require('govuk-react-components/components/forms/input-text');
-const RadioGroup = require('govuk-react-components/components/forms/radio-group');
-const Select = require('govuk-react-components/components/forms/select');
-const Date = require('govuk-react-components/components/forms/date');
+const Input = require('../../components/forms/input-text');
+const RadioGroup = require('../../components/forms/radio-group');
+const Select = require('../../components/forms/select');
+const Date = require('../../components/forms/date');
 
 class Index extends React.Component {
   render() {

--- a/example/views/layout.jsx
+++ b/example/views/layout.jsx
@@ -1,6 +1,6 @@
 const React = require('react');
-const GovUK = require('govuk-react-components/components/layout');
-const PhaseBanner = require('govuk-react-components/components/phase-banner');
+const GovUK = require('../../components/layout');
+const PhaseBanner = require('../../components/phase-banner');
 
 class Layout extends React.Component {
   render() {


### PR DESCRIPTION
It makes development against the local code a bit simpler when there's an immediately available codebase without having to `npm link`. It also saves having to keep the version up to date.