### PR TITLE
Make phase banner configurable

### DIFF
--- a/example/views/layout.jsx
+++ b/example/views/layout.jsx
@@ -7,7 +7,7 @@ class Layout extends React.Component {
     return (
       <GovUK propositionHeader={this.props.propositionHeader} title={this.props.title}>
         <main className="main" id="content">
-          <PhaseBanner phase="prototype" />
+          <PhaseBanner feedbackUrl="https://github.com/lennym/govuk-react-components" />
           <div className="grid-row">
 
             <div className="column-full">

--- a/src/__tests__/__snapshots__/phase-banner.spec.js.snap
+++ b/src/__tests__/__snapshots__/phase-banner.spec.js.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The Phase Banner Component should be empty if no feedbackUrl or children are provided 1`] = `
+<div
+  class="phase-banner"
+>
+  <p>
+    <strong
+      class="phase-tag"
+    >
+      beta
+    </strong>
+  </p>
+</div>
+`;
+
+exports[`The Phase Banner Component should contain any children that are passed 1`] = `
+<div
+  class="phase-banner"
+>
+  <p>
+    <strong
+      class="phase-tag"
+    >
+      beta
+    </strong>
+    <span>
+      My own custom text
+    </span>
+  </p>
+</div>
+`;
+
+exports[`The Phase Banner Component should contain default text and link if a feedback url is provided 1`] = `
+<div
+  class="phase-banner"
+>
+  <p>
+    <strong
+      class="phase-tag"
+    >
+      beta
+    </strong>
+    <span>
+      This is a new service – your 
+      <a
+        href="http://example.com"
+      >
+        feedback
+      </a>
+       will help us to improve it.
+    </span>
+  </p>
+</div>
+`;
+
+exports[`The Phase Banner Component should render a phase of "prototype" by default 1`] = `
+<div
+  class="phase-banner"
+>
+  <p>
+    <strong
+      class="phase-tag"
+    >
+      prototype
+    </strong>
+  </p>
+</div>
+`;
+
+exports[`The Phase Banner Component should render the phase when provided 1`] = `
+<div
+  class="phase-banner"
+>
+  <p>
+    <strong
+      class="phase-tag"
+    >
+      beta
+    </strong>
+  </p>
+</div>
+`;

--- a/src/__tests__/phase-banner.spec.js
+++ b/src/__tests__/phase-banner.spec.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { mount, render } from 'enzyme'
+import PhaseBanner from 'govuk-react-components/phase-banner';
+
+describe('The Phase Banner Component', () => {
+
+  it('should render a phase of "prototype" by default', () => {
+    expect(
+      render(<PhaseBanner />)
+    ).toMatchSnapshot()
+  });
+
+  it('should render the phase when provided', () => {
+    expect(
+      render(<PhaseBanner phase="beta" />)
+    ).toMatchSnapshot()
+  });
+
+  it('should contain any children that are passed', () => {
+    expect(
+      render(<PhaseBanner phase="beta"><span>My own custom text</span></PhaseBanner>)
+    ).toMatchSnapshot()
+  });
+
+  it('should contain default text and link if a feedback url is provided', () => {
+    expect(
+      render(<PhaseBanner phase="beta" feedbackUrl="http://example.com" />)
+    ).toMatchSnapshot()
+  });
+
+  it('should be empty if no feedbackUrl or children are provided', () => {
+    expect(
+      render(<PhaseBanner phase="beta" />)
+    ).toMatchSnapshot()
+  });
+
+})

--- a/src/phase-banner.jsx
+++ b/src/phase-banner.jsx
@@ -4,17 +4,14 @@ import PropTypes from 'prop-types';
 class PhaseBanner extends React.Component {
 
   renderContent() {
-    if (this.props.content) {
-      return this.props.content
+    if (this.props.children) {
+      return this.props.children;
     } else if (this.props.feedbackUrl) {
       return <span>This is a new service – your <a href={this.props.feedbackUrl}>feedback</a> will help us to improve it.</span>
     }
   }
 
   render() {
-    if (!this.props.phase) {
-      return;
-    }
 
     return <div className="phase-banner">
       <p>
@@ -36,8 +33,7 @@ PhaseBanner.defaultProps = {
 
 PhaseBanner.propTypes = {
   phase: PropTypes.oneOf(['prototype', 'alpha', 'beta']),
-  feedbackUrl: PropTypes.string,
-  content: PropTypes.node
+  feedbackUrl: PropTypes.string
 };
 
 export default PhaseBanner;

--- a/src/phase-banner.jsx
+++ b/src/phase-banner.jsx
@@ -3,6 +3,14 @@ import PropTypes from 'prop-types';
 
 class PhaseBanner extends React.Component {
 
+  renderContent() {
+    if (this.props.content) {
+      return this.props.content
+    } else if (this.props.feedbackUrl) {
+      return <span>This is a new service – your <a href={this.props.feedbackUrl}>feedback</a> will help us to improve it.</span>
+    }
+  }
+
   render() {
     if (!this.props.phase) {
       return;
@@ -11,7 +19,7 @@ class PhaseBanner extends React.Component {
     return <div className="phase-banner">
       <p>
         <strong className="phase-tag">{this.props.phase}</strong>
-        <span>This is a new service – your <a href="#">feedback</a> will help us to improve it.</span>
+        { this.renderContent() }
       </p>
     </div>
 
@@ -19,8 +27,17 @@ class PhaseBanner extends React.Component {
 
 }
 
+
+
+
+PhaseBanner.defaultProps = {
+  phase: 'prototype'
+};
+
 PhaseBanner.propTypes = {
-  phase: PropTypes.oneOf(['prototype', 'alpha', 'beta'])
+  phase: PropTypes.oneOf(['prototype', 'alpha', 'beta']),
+  feedbackUrl: PropTypes.string,
+  content: PropTypes.node
 };
 
 export default PhaseBanner;


### PR DESCRIPTION
If a feedback url is provided then use the standard text, otherwise allow the entire content to be passed as either a string or another react component.

Closes #8 