### PR TITLE
Use source code to generate test snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:unit-built": "jest --config ./scripts/jest/config.build.js --env=jsdom",
     "test:unit-source": "jest --config ./scripts/jest/config.source.js --env=jsdom",
     "test:watch": "npm run test:unit-source -- --watch",
-    "test:update": "npm run test -- --updateSnapshot",
+    "test:update": "npm run test:unit-source -- --updateSnapshot",
     "build": "npm run build:js && npm run build:css",
     "postbuild": "npm run test",
     "build:js": "babel ./src --out-dir ./components  --ignore '**/*.spec.js'",


### PR DESCRIPTION
This has the advantage of a) not running eslint needlessly when creating snapshots, and b) using the source code, rather than the current built version to generate snapshots, which is more likely to match user preference when wanting to test current in-development code.