### PR TITLE
Simplify example webserver

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -10,13 +10,8 @@ app.engine('jsx', require('express-react-views').createEngine());
 
 app.use(assets());
 
-app.use((req, res, next) => {
-  res.locals.propositionHeader = 'React Examples';
-  next();
-});
-
 app.get('/', (req, res) => {
-  res.render('index');
+  res.render('index', { propositionHeader: 'React Examples' });
 });
 
 app.listen(8080);


### PR DESCRIPTION
Passing the header directly to render is a bit simpler than mounting a middleware to do it.