### PR TITLE
Allow for totally custom proposition headers

### DIFF
--- a/src/layout.jsx
+++ b/src/layout.jsx
@@ -52,7 +52,13 @@ class Layout extends React.Component {
                 <div className="header-proposition">
                   <div className="content">
                     <nav id="proposition-menu">
-                      <a href={this.props.propositionHeaderLink} id="proposition-name">{this.props.propositionHeader}</a>
+                      {
+                        this.props.propositionHeaderLink &&
+                        <a href={this.props.propositionHeaderLink} id="proposition-name">{this.props.propositionHeader}</a>
+                      }
+                      {
+                        !this.props.propositionHeaderLink && this.props.propositionHeader
+                      }
                     </nav>
                   </div>
                 </div>


### PR DESCRIPTION
If `propositionHeaderLink` is not set (specifically if it is set to a falsy value to avoid breaking change) but a `propositionHeader` _is_ set, then render the `propositionHeader` without wrapping it in a link.

This is to allow fully custom header content - specifically for my use case a "logged in user" state.