### PR TITLE
Added PropType.node support for string props

### DIFF
--- a/src/forms/date.jsx
+++ b/src/forms/date.jsx
@@ -52,13 +52,13 @@ DateInput.defaultProps = {
 };
 
 DateInput.propTypes = {
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   id: PropTypes.string,
   value: Types.date,
-  hint: PropTypes.string,
-  error: PropTypes.string
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
 };
 
 export default DateInput;

--- a/src/forms/input-text.jsx
+++ b/src/forms/input-text.jsx
@@ -29,13 +29,13 @@ TextInput.defaultProps = {
 
 TextInput.propTypes = {
   name: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   onChange: PropTypes.func,
   id: PropTypes.string,
   type: PropTypes.string,
   value: PropTypes.string,
-  hint: PropTypes.string,
-  error: PropTypes.string
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
 };
 
 export default TextInput;

--- a/src/forms/radio-group.jsx
+++ b/src/forms/radio-group.jsx
@@ -41,7 +41,7 @@ class RadioGroup extends MultipleChoice(Input) {
                 name={this.props.name}
                 value={opt.value}
                 {...this.optProps(opt)}
-                />
+              />
               <label htmlFor={this.optionId(opt)}>{opt.label}</label>
             </div>
           ))
@@ -55,14 +55,14 @@ class RadioGroup extends MultipleChoice(Input) {
 RadioGroup.propTypes = {
   name: PropTypes.string.isRequired,
   options: Types.options.isRequired,
-  label:PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   onChange: PropTypes.func,
   id: PropTypes.string,
   type: PropTypes.oneOf(['radio', 'checkbox']),
   inline: PropTypes.bool,
   value: PropTypes.oneOfType([Types.value, PropTypes.arrayOf(Types.value)]),
-  hint: PropTypes.string,
-  error: PropTypes.string
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
 };
 
 export default RadioGroup;

--- a/src/forms/select.jsx
+++ b/src/forms/select.jsx
@@ -43,14 +43,15 @@ Select.defaultProps = {
 };
 
 Select.propTypes = {
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   name: PropTypes.string.isRequired,
   options: Types.options.isRequired,
   onChange: PropTypes.func,
   id: PropTypes.string,
   type: PropTypes.string,
   value: Types.value,
-  hint: PropTypes.string,
-  error: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   nullOption: PropTypes.string
 };
 

--- a/src/forms/textarea.jsx
+++ b/src/forms/textarea.jsx
@@ -36,12 +36,12 @@ TextArea.defaultProps = {
 
 TextArea.propTypes = {
   name: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   onChange: PropTypes.func,
   id: PropTypes.string,
   value: PropTypes.string,
-  hint: PropTypes.string,
-  error: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   cols: PropTypes.number,
   rows: PropTypes.number,
   disabled: PropTypes.bool,

--- a/src/types/options.js
+++ b/src/types/options.js
@@ -5,7 +5,7 @@ export default PropTypes.arrayOf(
   PropTypes.oneOfType([
     PropTypes.shape({
       value,
-      label: PropTypes.string
+      label: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
     }),
     value
   ])


### PR DESCRIPTION
We use a `<Snippet />` component for rendering text, this includes passsing it to form components as label, error and hint props.

Extended PropTypes to accept one of String or Node