### PR TITLE
Bugfix - added id to radio group

### DIFF
--- a/src/forms/__tests__/__snapshots__/radio-group.spec.js.snap
+++ b/src/forms/__tests__/__snapshots__/radio-group.spec.js.snap
@@ -6,6 +6,7 @@ exports[`The Radio Group Component should render a hint when a hint is passed in
 >
   <fieldset
     class=""
+    id="test"
   >
     <legend
       class="form-label-bold"
@@ -27,6 +28,7 @@ exports[`The Radio Group Component should render an error when an error is passe
 >
   <fieldset
     class=""
+    id="test"
   >
     <legend
       class="form-label-bold"
@@ -48,6 +50,7 @@ exports[`The Radio Group Component should render correctly as a controlled input
 >
   <fieldset
     class=""
+    id="test"
   >
     <legend
       class="form-label-bold"
@@ -95,6 +98,7 @@ exports[`The Radio Group Component should render correctly with multiple options
 >
   <fieldset
     class=""
+    id="test"
   >
     <legend
       class="form-label-bold"
@@ -141,6 +145,7 @@ exports[`The Radio Group Component should render correctly with multiple options
 >
   <fieldset
     class=""
+    id="test"
   >
     <legend
       class="form-label-bold"
@@ -188,6 +193,7 @@ exports[`The Radio Group Component should render correctly with no options 1`] =
 >
   <fieldset
     class=""
+    id="test"
   >
     <legend
       class="form-label-bold"

--- a/src/forms/radio-group.jsx
+++ b/src/forms/radio-group.jsx
@@ -28,7 +28,7 @@ class RadioGroup extends MultipleChoice(Input) {
   render() {
     const options = this.normaliseOptions();
     return <div className={this.errorClass('form-group')}>
-      <fieldset className={this.props.inline ? 'inline' : ''}>
+      <fieldset id={this.props.id || this.props.name} className={this.props.inline ? 'inline' : ''}>
         <legend className="form-label-bold">{this.props.label}</legend>
         { this.props.hint && <span className="form-hint">{this.props.hint}</span> }
         { this.props.error && <span className="error-message">{this.props.error}</span> }


### PR DESCRIPTION
If a radio group has an error, the link in the error summary doesn't link to the correct section of the page. Added id prop to fieldset which looks for ID prop, and falls back to name